### PR TITLE
Remove pyparsing version check from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,6 @@ version_dict = {}
 exec(open('src/pulp/constants.py').read(), version_dict)
 VERSION = version_dict['VERSION']
 
-#hack because pyparsing made version 2 python 3 specific
-if sys.version_info[0] <= 2:
-    pyparsing_ver = 'pyparsing<=1.9.9'
-else:
-    pyparsing_ver = 'pyparsing>=2.0.0'
-
 setup(name="PuLP",
       version=VERSION,
       description="""
@@ -68,7 +62,6 @@ problems.
                       'pulp.solverdir.cbc.win.64' : ['*','*.*'],
                       'pulp.solverdir.cbc.osx.64' : ['*','*.*'],
                       },
-      install_requires = [pyparsing_ver],
       entry_points = ("""
       [console_scripts]
       pulptest = pulp:pulpTestAll


### PR DESCRIPTION
According to [pyparsing changelog](http://pyparsing.wikispaces.com/News) from July 19, 2013:

> With release 2.0.1, I've removed the code that was specific to Python 3.x, so that it can be installed on any Python version 2.6 or later.

This makes pyparsing version check redundant as pulp has requirement for python version to be >= 2.6.
